### PR TITLE
Add auto-hotswapping functionality

### DIFF
--- a/Source/HotSwap.cs
+++ b/Source/HotSwap.cs
@@ -10,6 +10,7 @@ using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using RimWorld;
 using Verse;
+using UnityEngine;
 
 namespace HotSwap
 {
@@ -18,11 +19,23 @@ namespace HotSwap
         public static Dictionary<Assembly, FileInfo> AssemblyFiles;
         static Harmony harmony = new("HotSwap");
         static DateTime startTime = DateTime.Now;
+        internal static HotSwapSettings settings;
 
         public HotSwapMain(ModContentPack content) : base(content)
         {
             harmony.PatchAll();
             AssemblyFiles = MapModAssemblies();
+            settings = GetSettings<HotSwapSettings>();
+        }
+
+        public override string SettingsCategory()
+        {
+            return Content.Name;
+        }
+
+        public override void DoSettingsWindowContents(Rect inRect)
+        {
+            settings.DoSettingsWindowContents(inRect);
         }
 
         static Dictionary<Assembly, FileInfo> MapModAssemblies()

--- a/Source/HotSwapGameComponent.cs
+++ b/Source/HotSwapGameComponent.cs
@@ -1,0 +1,47 @@
+
+using System;
+using System.IO;
+using Verse;
+
+namespace HotSwap
+{
+    public class HotSwapGameComponent : GameComponent
+    {
+        private static TimeSpan UpdateFrequency = TimeSpan.FromSeconds(5);
+
+        private DateTime lastUpdate = DateTime.UtcNow;
+
+        public HotSwapGameComponent(Game _)
+        {
+        }
+
+        public override void GameComponentUpdate()
+        {
+            if (HotSwapMain.settings.EnableAutoHotSwap && (DateTime.UtcNow - lastUpdate) > UpdateFrequency)
+            {
+                bool triggerHotswap = false;
+                foreach (var assemblyFile in HotSwapMain.AssemblyFiles)
+                {
+                    var hotSwapFile = assemblyFile.Value.FullPath + ".hotswap";
+                    if (File.Exists(hotSwapFile))
+                    {
+                        try
+                        {
+                            File.Delete(hotSwapFile);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Warning($"Couldn't delete {hotSwapFile}: {ex}");
+                        }
+                        triggerHotswap = true;
+                    }
+                }
+                if (triggerHotswap)
+                {
+                    HotSwapMain.ScheduleHotSwap();
+                }
+                lastUpdate = DateTime.UtcNow;
+            }
+        }
+    }
+}

--- a/Source/HotSwapSettings.cs
+++ b/Source/HotSwapSettings.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+using Verse;
+
+
+namespace HotSwap
+{
+    public class HotSwapSettings : ModSettings
+    {
+        private bool _enableAutoHotSwap = false;
+        public bool EnableAutoHotSwap
+        {
+            get => _enableAutoHotSwap;
+        }
+
+        public override void ExposeData()
+        {
+            base.ExposeData();
+
+            Scribe_Values.Look(ref _enableAutoHotSwap, "enableAutoHotSwap", false);
+        }
+
+        internal void DoSettingsWindowContents(Rect inRect)
+        {
+            Listing_Standard listingStandard = new();
+            listingStandard.Begin(inRect);
+
+            listingStandard.CheckboxLabeled(
+                "Enable auto-hotswap",
+                ref _enableAutoHotSwap,
+                "If this setting is enabled, the mod will regularly look for a file named " +
+                "[AssemblyName].dll.hotswap next to any hot-swappable [AssemblyName].dll, " +
+                "and if it finds one, it will trigger a hot-swap, and then delete the " +
+                "[AssemblyName].dll.hotswap file.");
+
+            listingStandard.End();
+        }
+    }
+
+}


### PR DESCRIPTION
As the title suggests, this adds support for auto-hotswapping.

The way I made it is so that, at a five second interval, for all the assemblies in the `HotSwapMain.AssemblyFiles` dictionary, look for files named [PathToAssembly.dll].hotswap. If such a file exists, delete it, and then call `HotSwapMain.ScheduleHotSwap()`. This lets you easily add a step to your build script to create such a file after having built, thus saving you from even having to go into RimWorld and hit Home or click the hotswap button. Here's a small demo of it in action:

![Animation](https://github.com/Zetrith/HotSwap/assets/767490/f3deb9f6-f9fc-4c73-8023-475ed89ffcc6)

I also added a settings dialog to turn the feature on or off. (It is off by default)

I have not updated the dlls because I don't think it's sensible to rely on external contributors providing safe ones in PRs.